### PR TITLE
Support BF request throttling

### DIFF
--- a/BFHelpers.cs
+++ b/BFHelpers.cs
@@ -99,8 +99,9 @@ namespace BetfairNG
                 .Where(c => c.Status == RunnerStatus.ACTIVE)
                 .Select(c => c.ExchangePrices.AvailableToLay.Count > 0 ? c.ExchangePrices.AvailableToLay.First().Price : 0.0);
 
-            var timeToJump = marketCatalogue.Description.MarketTime;
-            var timeRemainingToJump = timeToJump.Subtract(DateTime.Now.AddHours(7));
+            // OpenDate is always populated, MarketTime may not be
+            var timeToJump = Convert.ToDateTime(marketCatalogue.Event.OpenDate);
+            var timeRemainingToJump = timeToJump.Subtract(DateTime.UtcNow);
 
             var sb = new StringBuilder()
                         .AppendFormat("{0} {1}", marketCatalogue.Event.Name, marketCatalogue.MarketName)
@@ -112,7 +113,7 @@ namespace BetfairNG
                         .AppendFormat(" : Avail={0}", marketBook.TotalAvailable.ToString("C0"));
             sb.AppendLine();
             sb.AppendFormat("Time To Jump: {0}h {1}:{2}",
-                  timeRemainingToJump.Hours,
+                  timeRemainingToJump.Hours + (timeRemainingToJump.Days * 24),
                   timeRemainingToJump.Minutes.ToString("##"),
                   timeRemainingToJump.Seconds.ToString("##"));
             sb.AppendLine();
@@ -127,7 +128,7 @@ namespace BetfairNG
 
                     string consoleRunnerName = runnerName != null ? runnerName.RunnerName : "null";
 
-                    sb.AppendLine(string.Format("{0}\t {9} [{1}] {2},{3},{4}  ::  {5},{6},{7} [{8}] {10}",
+                    sb.AppendLine(string.Format("{0} {9} [{1}] {2},{3},{4}  ::  {5},{6},{7} [{8}] {10}",
                         consoleRunnerName.PadRight(25),
                         runner.ExchangePrices.AvailableToBack.Sum(a => a.Size).ToString("0").PadLeft(7),
                         runner.ExchangePrices.AvailableToBack.Count > 2 ? runner.ExchangePrices.AvailableToBack[2].Price.ToString("0.00").PadLeft(6) : "  0.00",
@@ -256,7 +257,7 @@ namespace BetfairNG
 
             int index = 0;
             // 9.9 (not valid)
-            for (int i = 0; i < Table.Length; i++)
+            for (int i = 1; i < Table.Length; i++)
             {
                 if (Table[i] > price)
                     return Table[index];

--- a/BetfairNG.csproj
+++ b/BetfairNG.csproj
@@ -11,6 +11,10 @@
     <AssemblyName>BetfairNG</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,25 +34,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="MoreLinq.Portable">
+      <HintPath>packages\MoreLinq.Portable.1.1.0\lib\portable-net4+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\MoreLinq.Portable.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Reactive.Core">
       <HintPath>packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Reactive.Interfaces">
       <HintPath>packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Reactive.Linq">
       <HintPath>packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Reactive.PlatformServices">
       <HintPath>packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -59,7 +63,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BetfairClient.cs" />
-    <Compile Include="BetfairClientSync.cs" />
     <Compile Include="BFHelpers.cs" />
     <Compile Include="Data\AccountDetailsResponse.cs" />
     <Compile Include="Data\AccountFundsResponse.cs" />
@@ -148,7 +151,9 @@
     <Compile Include="Network.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="README.md" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Data/MarketProjection.cs
+++ b/Data/MarketProjection.cs
@@ -15,6 +15,7 @@ namespace BetfairNG.Data
         EVENT_TYPE, 
         MARKET_DESCRIPTION, 
         RUNNER_DESCRIPTION, 
-        RUNNER_METADATA 
+        RUNNER_METADATA,
+        MARKET_START_TIME
     }
 }

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
+  <package id="MoreLinq.Portable" version="1.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
I'm submitting this pull request on behalf of Zac Sky. We have embarked on a project that covers a wide range of BF markets and requires support for BF request throttling. As such Zac has updated MarketListener to support BF request throttling when retrieving MarketBooks and added a KeepAlive method to BetfairClient.